### PR TITLE
added TPM_PCR_INIT_VALUE as a prepended eventlog entry

### DIFF
--- a/parse-srtm-pcrs/eventcb.h
+++ b/parse-srtm-pcrs/eventcb.h
@@ -22,6 +22,9 @@ bool
 event_specid_cb(TCG_EVENT const *event, void *data);
 
 bool
+event_initval_cb(void *data, int locality, int pcr);
+
+bool
 event_header_cb(TCG_EVENT const *event_hdr, size_t size, void *data);
 
 bool

--- a/parse-srtm-pcrs/main.c
+++ b/parse-srtm-pcrs/main.c
@@ -60,6 +60,7 @@ tpm_parse_eventlog(cb_data_t *cb_data, const char *filename)
     tpm2_eventlog_context ctx = {
         .data = cb_data,
         .specid_cb = event_specid_cb,
+        .initval_cb = event_initval_cb,
         .event2hdr_cb = event2_header_cb,
         .log_eventhdr_cb = event_header_cb,
         .digest2_cb = event_digest_cb,

--- a/parse-srtm-pcrs/thirdparty/tpm2-tools/tpm2_eventlog.h
+++ b/parse-srtm-pcrs/thirdparty/tpm2-tools/tpm2_eventlog.h
@@ -16,6 +16,7 @@ typedef bool (*EVENT2_CALLBACK)(TCG_EVENT_HEADER2 const *event_hdr, size_t size,
 typedef bool (*EVENT2DATA_CALLBACK)(TCG_EVENT2 const *event, UINT32 type,
                                     void *data, uint32_t eventlog_version);
 typedef bool (*SPECID_CALLBACK)(TCG_EVENT const *event, void *data);
+typedef bool (*INITVAL_CALLBACK)(void *data, int locality, int pcr);
 typedef bool (*LOG_EVENT_CALLBACK)(TCG_EVENT const *event_hdr, size_t size,
                                    void *data);
 
@@ -23,6 +24,7 @@ typedef bool (*LOG_EVENT_CALLBACK)(TCG_EVENT const *event_hdr, size_t size,
 typedef struct {
     void *data;
     SPECID_CALLBACK specid_cb;
+    INITVAL_CALLBACK initval_cb;
     LOG_EVENT_CALLBACK log_eventhdr_cb;
     EVENT2_CALLBACK event2hdr_cb;
     DIGEST2_CALLBACK digest2_cb;


### PR DESCRIPTION
a TPM_PCR_INIT_VALUE is a eventlog entry that contains the locality for each PCR. It is prepended to each PCR.